### PR TITLE
Load swagger configuration from Spring properties. Fixes #66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,26 @@
     </dependencyManagement>
 
     <build>
+        <resources>
+            <!-- need to filter resources to replace application version in Spring properties -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
+            <!-- necessary to use @ as a placeholder in Spring properties -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <delimiters>
+                        <delimiter>@</delimiter>
+                    </delimiters>
+                    <useDefaultDelimiters>false</useDefaultDelimiters>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/src/main/java/edu/monash/monplan/config/SwaggerConfig.java
+++ b/src/main/java/edu/monash/monplan/config/SwaggerConfig.java
@@ -1,8 +1,10 @@
 package edu.monash.monplan.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
@@ -13,6 +15,16 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig extends WebMvcConfigurerAdapter {
+
+    @Value("${spring.application.version}")
+    private String applicationVersion;
+    @Value("${spring.application.title}")
+    private String applicationTitle;
+    @Value("${spring.application.description}")
+    private String applicationDescription;
+    @Value("${spring.application.contact}")
+    private String applicationContact;
+
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
@@ -26,14 +38,15 @@ public class SwaggerConfig extends WebMvcConfigurerAdapter {
 
     private ApiInfo apiDocInfo() {
         // you can update the configuration here
-        ApiInfo apiInfo = new ApiInfo(
-                "My REST API",
-                "Some custom description of API.",
-                "v2",
-                "Terms of service",
-                "esol-monplan-ops-l@monash.edu",
-                "MIT",
-                "https://github.com/lorderikir/springboot-base-gae-java8/blob/master/LICENSE");
+        ApiInfo apiInfo = new ApiInfoBuilder()
+                .title(applicationTitle)
+                .description(applicationDescription)
+                .version(applicationVersion)
+                //.termsOfServiceUrl("Terms of service")
+                .contact(applicationContact)
+                .license("MIT")
+                .licenseUrl("https://github.com/lorderikir/springboot-base-gae-java8/blob/master/LICENSE")
+                .build();
         return apiInfo;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 #### Spring config goes here and other app config
+spring.application.version=@project.version@
+spring.application.title=@project.artifactId@
+spring.application.description=
+spring.application.contact=esol-monplan-ops-l@monash.edu


### PR DESCRIPTION
This method makes use of Maven resource filtering and manual
configuration of properties in Springs application.properties file.
The Swagger configuration is build using Spring `@Value` to get the
configured properties for each.

I left out the TOS, because it was just a placeholder and I also left
the license and URL to license hardcoded.